### PR TITLE
Use bimap instead of oneway map

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+bimap = "0.6"


### PR DESCRIPTION
This fixes the problem of the map potentially growing unbounded.

Switches to using a two way hashmap that will hash keys to values and values to keys. This will prevent more than one key being mapped to the same index. Any old key will get removed when a new key has that same index as its mapped value.

Closes #1 